### PR TITLE
Fix benchmark_stim.py not asking for bit packed data

### DIFF
--- a/example/benchmark_stim.py
+++ b/example/benchmark_stim.py
@@ -3,7 +3,7 @@ from time import time
 
 circuit = stim.Circuit.from_file(f"./stim_benchmark/random10.stim")
 sampler = circuit.compile_sampler()
-sampler.sample(shots=10000)
+sampler.sample(shots=10000, bit_packed=True)
 
 with open("./benchmark_stim.dat", "w") as io:
     print("nq init_time sample_time", file=io)
@@ -12,7 +12,7 @@ with open("./benchmark_stim.dat", "w") as io:
         circuit = stim.Circuit.from_file(f"./stim_benchmark/random{j}.stim")
         sampler = circuit.compile_sampler()
         t1 = time()
-        sampler.sample(shots=10000)
+        sampler.sample(shots=10000, bit_packed=True)
         t2 = time()
         print(f"{j} {t1-t0} {t2-t1}", file=io)
         print(f"{j} {t1-t0} {t2-t1}")


### PR DESCRIPTION
Forgetting to ask for bit packed data forces stim to turn each bit into a byte, returning 8x more data than necessary. This is roughly a 5x slowdown on the benchmark (0.9s -> 0.2s at n=10000). It doesn't change the message that QuantumSE is substantially faster at these circuits, but 5x is 5x.

---

There is *technically* another 2x in performance available by using the command line tool or directly using the C++ API (0.2s -> 0.1s). The C++ API in particular avoids the cost of transposing the results and of allocating numpy arrays and of copying the results into the numpy arrays. (These are also costs not paid by the Julia code.) That said, it is reasonable to compare against the python API since that's what users actually use in practice.

```
#include <chrono>
#include "stim.h"

int main(int argc, const char **argv) {
    FILE *f = fopen("stim_benchmark/random1000.stim", "r");
    stim::Circuit c = stim::Circuit::from_file(f);
    fclose(f);
    auto ref_sample = stim::TableauSimulator<stim::MAX_BITWORD_WIDTH>::reference_sample_circuit(c);
    stim::FrameSimulator<stim::MAX_BITWORD_WIDTH> sim(c.compute_stats(), stim::FrameSimulatorMode::STORE_MEASUREMENTS_TO_MEMORY, 10000, {});

    auto start = std::chrono::high_resolution_clock::now();
    sim.reset_all();
    sim.do_circuit(c);
    for (size_t k = 0; k < 10000; k++) {
        if (ref_sample[k]) {
            sim.m_record.storage[k].invert_bits();
        }
    }
    auto end = std::chrono::high_resolution_clock::now();
    auto microseconds = std::chrono::duration_cast<std::chrono::milliseconds>(end-start);
    std::cout << microseconds.count() << "millis\n";
}
```

```
121 millis
```

A potential issue with the benchmark here is that random circuits are highly atypical, and QuantumSE is benefiting heavily from the way that they are atypical. About 90% of measurements performed in these random circuits anticommute with the current stabilizers. The result is that chains of dependent measurements are extremely short; constant in length. This results in the raw-entropy-to-samples matrix being extremely sparse; almost a permutation matrix! This heavily favors QuantumSE's representation. Comparing on surface code circuits or Bacon-Shor circuits would give qualitatively different results.